### PR TITLE
Fixing README: remote plugin name was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ theme: bay_jekyll_theme
 ```
 or, for GitHub Pages:
 ```
-remote_theme: eliottvincent/bay_jekyll_theme
+remote_theme: eliottvincent/bay
 ```
 
 Finally, install the dependencies:


### PR DESCRIPTION
Trying to setup the theme for my github page, `jekyll serve` was giving me a 404 error when trying to download: https://codeload.github.com/eliottvincent/bay_jekyll_theme/zip/master. 

Changing the remote_theme name to just `bay` solves it.

